### PR TITLE
Victor/adding more abstractions

### DIFF
--- a/include/bm_os.h
+++ b/include/bm_os.h
@@ -45,6 +45,7 @@ BmErr bm_timer_start(BmTimer timer, uint32_t timeout_ms);
 BmErr bm_timer_stop(BmTimer timer, uint32_t timeout_ms);
 BmErr bm_timer_change_period(BmTimer timer, uint32_t period_ms, uint32_t timeout_ms);
 uint32_t bm_get_tick_count(void);
+uint32_t bm_get_tick_count_from_isr(void);
 uint32_t bm_ms_to_ticks(uint32_t ms);
 uint32_t bm_ticks_to_ms(uint32_t ticks);
 void bm_delay(uint32_t ms);

--- a/include/bm_os.h
+++ b/include/bm_os.h
@@ -52,6 +52,7 @@ uint32_t bm_ms_to_ticks(uint32_t ms);
 uint32_t bm_ticks_to_ms(uint32_t ticks);
 void bm_delay(uint32_t ms);
 
+// These use time_remaining from util.c
 #define time_remaining_ticks(startTicks, timeoutTicks)                         \
   time_remaining(startTicks, bm_get_tick_count(), timeoutTicks)
 #define time_remaining_ticks_from_ISR(startTicks, timeoutTicks)                \

--- a/include/bm_os.h
+++ b/include/bm_os.h
@@ -34,21 +34,36 @@ BmErr bm_semaphore_give(BmSemaphore semaphore);
 BmErr bm_semaphore_take(BmSemaphore semaphore, uint32_t timeout_ms);
 
 // Task functions
-BmErr bm_task_create(void (*task)(void *), const char *name, uint32_t stack_size, void *arg,
-                       uint32_t priority, void *task_handle);
+BmErr bm_task_create(void (*task)(void *), const char *name,
+                     uint32_t stack_size, void *arg, uint32_t priority,
+                     void *task_handle);
 void bm_start_scheduler(void);
 
 // Timer functions
-BmTimer bm_timer_create(void (*callback)(void *), const char *name, uint32_t period_ms,
-                        void *arg);
+BmTimer bm_timer_create(void (*callback)(void *), const char *name,
+                        uint32_t period_ms, void *arg);
 BmErr bm_timer_start(BmTimer timer, uint32_t timeout_ms);
 BmErr bm_timer_stop(BmTimer timer, uint32_t timeout_ms);
-BmErr bm_timer_change_period(BmTimer timer, uint32_t period_ms, uint32_t timeout_ms);
+BmErr bm_timer_change_period(BmTimer timer, uint32_t period_ms,
+                             uint32_t timeout_ms);
 uint32_t bm_get_tick_count(void);
 uint32_t bm_get_tick_count_from_isr(void);
 uint32_t bm_ms_to_ticks(uint32_t ms);
 uint32_t bm_ticks_to_ms(uint32_t ticks);
 void bm_delay(uint32_t ms);
+
+#define time_remaining_ticks(startTicks, timeoutTicks)                         \
+  time_remaining(startTicks, bm_get_tick_count(), timeoutTicks)
+#define time_remaining_ticks_from_ISR(startTicks, timeoutTicks)                \
+  time_remaining(startTicks, bm_get_tick_count_from_isr(), timeoutTicks)
+#define time_remaining_ms(startTimeMs, timeoutMs)                              \
+  bm_ticks_to_ms(time_remaining(bm_ms_to_ticks(startTimeMs),                   \
+                                bm_get_tick_count(),                           \
+                                bm_ms_to_ticks(timeoutMs)))
+#define time_remaining_ms_from_ISR(startTimeMs, timeoutMs)                     \
+  bm_ticks_to_ms(time_remaining(bm_ms_to_ticks(startTimeMs),                   \
+                                bm_get_tick_count_from_isr(),                  \
+                                bm_ms_to_ticks(timeoutMs)))
 
 #ifdef __cplusplus
 }

--- a/include/util.h
+++ b/include/util.h
@@ -55,7 +55,7 @@ typedef struct {
 uint32_t time_remaining(uint32_t start, uint32_t current, uint32_t timeout);
 uint32_t utc_from_date_time(uint16_t year, uint8_t month, uint8_t day,
                             uint8_t hour, uint8_t minute, uint8_t second);
-void date_time_from_utc(uint64_t utc_us, UtcDateTime *dateTime);
+void date_time_from_utc(uint64_t utc_us, UtcDateTime *date_time);
 
 #define bm_err_check(e, f)                                                     \
   if (e == BmOK) {                                                             \

--- a/include/util.h
+++ b/include/util.h
@@ -42,6 +42,18 @@ typedef enum {
 #define array_size(x) (sizeof(x) / sizeof(x[0]))
 #define member_size(type, member) (sizeof(((type *)0)->member))
 
+#define timeRemainingTicks(startTicks, timeoutTicks)                                           \
+  timeRemainingGeneric(startTicks, bm_get_tick_count(), timeoutTicks)
+#define timeRemainingTicksFromISR(startTicks, timeoutTicks)                                    \
+  timeRemainingGeneric(startTicks, bm_get_tick_count_from_isr(), timeoutTicks)
+#define timeRemainingMs(startTimeMs, timeoutMs)                                                \
+  bm_ticks_to_ms(timeRemainingGeneric(bm_ms_to_ticks(startTimeMs), bm_get_tick_count(),          \
+                                     bm_ms_to_ticks(timeoutMs)))
+#define timeRemainingMsFromISR(startTimeMs, timeoutMs)                                         \
+  bm_ticks_to_ms(timeRemainingGeneric(bm_ms_to_ticks(startTimeMs), bm_get_tick_count_from_isr(),   \
+                                     bm_ms_to_ticks(timeoutMs)))
+
+
 #define bm_err_check(e, f)                                                     \
   if (e == BmOK) {                                                             \
     e = f;                                                                     \

--- a/include/util.h
+++ b/include/util.h
@@ -39,22 +39,23 @@ typedef enum {
 #define bcmp_topo_task_priority 3
 #endif
 
+typedef struct {
+  uint16_t year;
+  uint8_t month;
+  uint8_t day;
+  uint8_t hour;
+  uint8_t min;
+  uint8_t sec;
+  uint32_t usec;
+} UtcDateTime;
+
 #define array_size(x) (sizeof(x) / sizeof(x[0]))
 #define member_size(type, member) (sizeof(((type *)0)->member))
 
 uint32_t time_remaining(uint32_t start, uint32_t current, uint32_t timeout);
-
-#define time_remaining_ticks(startTicks, timeoutTicks)                                           \
-  time_remaining(startTicks, bm_get_tick_count(), timeoutTicks)
-#define time_remaining_ticks_from_ISR(startTicks, timeoutTicks)                                    \
-  time_remaining(startTicks, bm_get_tick_count_from_isr(), timeoutTicks)
-#define time_remaining_ms(startTimeMs, timeoutMs)                                                \
-  bm_ticks_to_ms(time_remaining(bm_ms_to_ticks(startTimeMs), bm_get_tick_count(),          \
-                                     bm_ms_to_ticks(timeoutMs)))
-#define time_remaining_ms_from_ISR(startTimeMs, timeoutMs)                                         \
-  bm_ticks_to_ms(time_remaining(bm_ms_to_ticks(startTimeMs), bm_get_tick_count_from_isr(),   \
-                                     bm_ms_to_ticks(timeoutMs)))
-
+uint32_t utc_from_date_time(uint16_t year, uint8_t month, uint8_t day,
+                            uint8_t hour, uint8_t minute, uint8_t second);
+void date_time_from_utc(uint64_t utc_us, UtcDateTime *dateTime);
 
 #define bm_err_check(e, f)                                                     \
   if (e == BmOK) {                                                             \

--- a/include/util.h
+++ b/include/util.h
@@ -53,6 +53,20 @@ typedef struct {
 #define member_size(type, member) (sizeof(((type *)0)->member))
 
 uint32_t time_remaining(uint32_t start, uint32_t current, uint32_t timeout);
+
+#define time_remaining_ticks(startTicks, timeoutTicks)                         \
+  time_remaining(startTicks, bm_get_tick_count(), timeoutTicks)
+#define time_remaining_ticks_from_ISR(startTicks, timeoutTicks)                \
+  time_remaining(startTicks, bm_get_tick_count_from_isr(), timeoutTicks)
+#define time_remaining_ms(startTimeMs, timeoutMs)                              \
+  bm_ticks_to_ms(time_remaining(bm_ms_to_ticks(startTimeMs),                   \
+                                bm_get_tick_count(),                           \
+                                bm_ms_to_ticks(timeoutMs)))
+#define time_remaining_ms_from_ISR(startTimeMs, timeoutMs)                     \
+  bm_ticks_to_ms(time_remaining(bm_ms_to_ticks(startTimeMs),                   \
+                                bm_get_tick_count_from_isr(),                  \
+                                bm_ms_to_ticks(timeoutMs)))
+
 uint32_t utc_from_date_time(uint16_t year, uint8_t month, uint8_t day,
                             uint8_t hour, uint8_t minute, uint8_t second);
 void date_time_from_utc(uint64_t utc_us, UtcDateTime *date_time);

--- a/include/util.h
+++ b/include/util.h
@@ -42,15 +42,17 @@ typedef enum {
 #define array_size(x) (sizeof(x) / sizeof(x[0]))
 #define member_size(type, member) (sizeof(((type *)0)->member))
 
-#define timeRemainingTicks(startTicks, timeoutTicks)                                           \
-  timeRemainingGeneric(startTicks, bm_get_tick_count(), timeoutTicks)
-#define timeRemainingTicksFromISR(startTicks, timeoutTicks)                                    \
-  timeRemainingGeneric(startTicks, bm_get_tick_count_from_isr(), timeoutTicks)
-#define timeRemainingMs(startTimeMs, timeoutMs)                                                \
-  bm_ticks_to_ms(timeRemainingGeneric(bm_ms_to_ticks(startTimeMs), bm_get_tick_count(),          \
+uint32_t time_remaining(uint32_t start, uint32_t current, uint32_t timeout);
+
+#define time_remaining_ticks(startTicks, timeoutTicks)                                           \
+  time_remaining(startTicks, bm_get_tick_count(), timeoutTicks)
+#define time_remaining_ticks_from_ISR(startTicks, timeoutTicks)                                    \
+  time_remaining(startTicks, bm_get_tick_count_from_isr(), timeoutTicks)
+#define time_remaining_ms(startTimeMs, timeoutMs)                                                \
+  bm_ticks_to_ms(time_remaining(bm_ms_to_ticks(startTimeMs), bm_get_tick_count(),          \
                                      bm_ms_to_ticks(timeoutMs)))
-#define timeRemainingMsFromISR(startTimeMs, timeoutMs)                                         \
-  bm_ticks_to_ms(timeRemainingGeneric(bm_ms_to_ticks(startTimeMs), bm_get_tick_count_from_isr(),   \
+#define time_remaining_ms_from_ISR(startTimeMs, timeoutMs)                                         \
+  bm_ticks_to_ms(time_remaining(bm_ms_to_ticks(startTimeMs), bm_get_tick_count_from_isr(),   \
                                      bm_ms_to_ticks(timeoutMs)))
 
 
@@ -78,7 +80,6 @@ typedef struct {
 extern const bm_ip_addr multicast_global_addr;
 extern const bm_ip_addr multicast_ll_addr;
 
-uint32_t time_remaining(uint32_t start, uint32_t current, uint32_t timeout);
 bool is_little_endian(void);
 void swap_16bit(void *x);
 void swap_32bit(void *x);

--- a/include/util.h
+++ b/include/util.h
@@ -53,20 +53,6 @@ typedef struct {
 #define member_size(type, member) (sizeof(((type *)0)->member))
 
 uint32_t time_remaining(uint32_t start, uint32_t current, uint32_t timeout);
-
-#define time_remaining_ticks(startTicks, timeoutTicks)                         \
-  time_remaining(startTicks, bm_get_tick_count(), timeoutTicks)
-#define time_remaining_ticks_from_ISR(startTicks, timeoutTicks)                \
-  time_remaining(startTicks, bm_get_tick_count_from_isr(), timeoutTicks)
-#define time_remaining_ms(startTimeMs, timeoutMs)                              \
-  bm_ticks_to_ms(time_remaining(bm_ms_to_ticks(startTimeMs),                   \
-                                bm_get_tick_count(),                           \
-                                bm_ms_to_ticks(timeoutMs)))
-#define time_remaining_ms_from_ISR(startTimeMs, timeoutMs)                     \
-  bm_ticks_to_ms(time_remaining(bm_ms_to_ticks(startTimeMs),                   \
-                                bm_get_tick_count_from_isr(),                  \
-                                bm_ms_to_ticks(timeoutMs)))
-
 uint32_t utc_from_date_time(uint16_t year, uint8_t month, uint8_t day,
                             uint8_t hour, uint8_t minute, uint8_t second);
 void date_time_from_utc(uint64_t utc_us, UtcDateTime *date_time);

--- a/src/platform/bm_freertos.c
+++ b/src/platform/bm_freertos.c
@@ -94,6 +94,8 @@ BmErr bm_timer_change_period(BmTimer timer, uint32_t period_ms, uint32_t timeout
 
 uint32_t bm_get_tick_count(void) { return xTaskGetTickCount(); }
 
+uint32_t bm_get_tick_count_from_isr(void) { return xTaskGetTickCountFromISR(); }
+
 uint32_t bm_ms_to_ticks(uint32_t ms) { return pdMS_TO_TICKS(ms); }
 
 uint32_t bm_ticks_to_ms(uint32_t ticks) { return pdTICKS_TO_MS(ticks); }

--- a/src/util.c
+++ b/src/util.c
@@ -111,39 +111,39 @@ static const uint8_t *get_days_per_month(uint32_t year) {
   \param[out] UtcDateTime - date time
   \return None
 */
-void date_time_from_utc(uint64_t utc_us, UtcDateTime *dateTime) {
+void date_time_from_utc(uint64_t utc_us, UtcDateTime *date_time) {
   // TODO - Do we really need this?
   // configASSERT(dateTime);
 
   // year
   uint64_t days = (utc_us / MICROSECONDS_PER_SECOND) / SECS_PER_DAY;
-  dateTime->year = 1970;
-  while (days >= get_days_for_year(dateTime->year)) {
-    days -= get_days_for_year(dateTime->year);
-    dateTime->year++;
+  date_time->year = 1970;
+  while (days >= get_days_for_year(date_time->year)) {
+    days -= get_days_for_year(date_time->year);
+    date_time->year++;
   }
 
   // months
-  const uint8_t *monthDays = get_days_per_month(dateTime->year);
-  dateTime->month = 1;
-  while (days >= monthDays[dateTime->month - 1]) {
-    days -= monthDays[dateTime->month - 1];
-    dateTime->month++;
+  const uint8_t *monthDays = get_days_per_month(date_time->year);
+  date_time->month = 1;
+  while (days >= monthDays[date_time->month - 1]) {
+    days -= monthDays[date_time->month - 1];
+    date_time->month++;
   }
 
   // days
-  dateTime->day = days + 1;
+  date_time->day = days + 1;
 
   uint64_t secondsRemaining = (utc_us / MICROSECONDS_PER_SECOND) % SECS_PER_DAY;
   // hours
-  dateTime->hour = secondsRemaining / SECS_PER_HOUR;
+  date_time->hour = secondsRemaining / SECS_PER_HOUR;
 
   // minutes
-  dateTime->min = (secondsRemaining / SECS_PER_MIN) % SECS_PER_MIN;
+  date_time->min = (secondsRemaining / SECS_PER_MIN) % SECS_PER_MIN;
 
   // seconds
-  dateTime->sec = secondsRemaining % SECS_PER_MIN;
+  date_time->sec = secondsRemaining % SECS_PER_MIN;
 
   // useconds
-  dateTime->usec = utc_us % MICROSECONDS_PER_SECOND;
+  date_time->usec = utc_us % MICROSECONDS_PER_SECOND;
 }

--- a/src/util.c
+++ b/src/util.c
@@ -35,3 +35,115 @@ void swap_64bit(void *x) {
          ((*swp >> 8) & 0xFF000000) | ((*swp >> 24) & 0x00FF0000) |
          ((*swp >> 40) & 0x0000FF00) | (*swp >> 56);
 }
+
+// leap year calulator expects year argument as years offset from 1970
+#define LEAP_YEAR(Y)                                                           \
+  (((1970 + Y) > 0) && !((1970 + Y) % 4) &&                                    \
+   (((1970 + Y) % 100) || !((1970 + Y) % 400)))
+
+#define SECS_PER_MIN (60UL)
+#define SECS_PER_HOUR (3600UL)
+#define SECS_PER_DAY (SECS_PER_HOUR * 24UL)
+#define MICROSECONDS_PER_SECOND (1000000)
+
+static const uint8_t MONTH_DAYS[] = {
+    31, 28, 31, 30, 31, 30, 31,
+    31, 30, 31, 30, 31}; // API starts months from 1, this array starts from 0
+static const uint8_t MONTH_DAYS_LEAP_YEAR[] = {
+    31, 29, 31, 30, 31, 30, 31,
+    31, 30, 31, 30, 31}; // API starts months from 1, this array starts from 0
+
+/*!
+  Convert date (YYYYMMDDhhmmss) into unix timestamp(UTC)
+
+  \param[in] year - Full year (2022, for example)
+  \param[in] month - Month starting at 1
+  \param[in] day - Day starting at 1
+  \param[in] hour - Hour starting at 0 and ending at 23
+  \param[in] minute - Minute starting at 0 and ending at 59
+  \param[in] second - Minute starting at 0 and ending at 59
+  \return UTC seconds since Jan 1st 1970 00:00:00
+*/
+uint32_t utc_from_date_time(uint16_t year, uint8_t month, uint8_t day,
+                            uint8_t hour, uint8_t minute, uint8_t second) {
+  int i;
+  uint32_t seconds;
+
+  // seconds from 1970 till 1 jan 00:00:00 of the given year
+  seconds = (year - 1970) * (SECS_PER_DAY * 365);
+  for (i = 1970; i < year; i++) {
+    if (LEAP_YEAR(i - 1970)) {
+      seconds += SECS_PER_DAY; // add extra days for leap years
+    }
+  }
+
+  // add days for this year, months start from 1
+  for (i = 1; i < month; i++) {
+    if ((i == 2) && LEAP_YEAR(year - 1970)) {
+      seconds += SECS_PER_DAY * 29;
+    } else {
+      seconds +=
+          SECS_PER_DAY * MONTH_DAYS[i - 1]; //monthDay array starts from 0
+    }
+  }
+  seconds += (day - 1) * SECS_PER_DAY;
+  seconds += hour * SECS_PER_HOUR;
+  seconds += minute * SECS_PER_MIN;
+  seconds += second;
+  return seconds;
+}
+
+#define DAYS_PER_YEAR (365)
+#define DAYS_PER_LEAP_YEAR (DAYS_PER_YEAR + 1)
+
+static uint32_t get_days_for_year(uint32_t year) {
+  return LEAP_YEAR(year - 1970) ? DAYS_PER_LEAP_YEAR : DAYS_PER_YEAR;
+}
+
+static const uint8_t *get_days_per_month(uint32_t year) {
+  return LEAP_YEAR(year - 1970) ? MONTH_DAYS_LEAP_YEAR : MONTH_DAYS;
+}
+
+/*!
+  Convert unix timestamp(UTC) in microseconds to date (YYYYMMDDhhmmss)
+
+  \param[in] utc_us - utc in microseconds
+  \param[out] UtcDateTime - date time
+  \return None
+*/
+void date_time_from_utc(uint64_t utc_us, UtcDateTime *dateTime) {
+  // TODO - Do we really need this?
+  // configASSERT(dateTime);
+
+  // year
+  uint64_t days = (utc_us / MICROSECONDS_PER_SECOND) / SECS_PER_DAY;
+  dateTime->year = 1970;
+  while (days >= get_days_for_year(dateTime->year)) {
+    days -= get_days_for_year(dateTime->year);
+    dateTime->year++;
+  }
+
+  // months
+  const uint8_t *monthDays = get_days_per_month(dateTime->year);
+  dateTime->month = 1;
+  while (days >= monthDays[dateTime->month - 1]) {
+    days -= monthDays[dateTime->month - 1];
+    dateTime->month++;
+  }
+
+  // days
+  dateTime->day = days + 1;
+
+  uint64_t secondsRemaining = (utc_us / MICROSECONDS_PER_SECOND) % SECS_PER_DAY;
+  // hours
+  dateTime->hour = secondsRemaining / SECS_PER_HOUR;
+
+  // minutes
+  dateTime->min = (secondsRemaining / SECS_PER_MIN) % SECS_PER_MIN;
+
+  // seconds
+  dateTime->sec = secondsRemaining % SECS_PER_MIN;
+
+  // useconds
+  dateTime->usec = utc_us % MICROSECONDS_PER_SECOND;
+}


### PR DESCRIPTION
Bring over some utc -> datetime and datetime -> utc conversion functions. Also add some more time remaining functions. The utc/datetime functions are used by bcmp_time.