### PR TITLE
Adds aligned_malloc from bm_protocol to bm_common

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,7 @@ if(ENABLE_TESTING)
     add_subdirectory("test")
 else()
     set(SOURCES
+        src/aligned_malloc.c
         src/util.c
         src/ll.c
         src/lib_state_machine.c

--- a/include/aligned_malloc.h
+++ b/include/aligned_malloc.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdlib.h>
+
+void *aligned_malloc(size_t align, size_t size);
+void aligned_free(void *ptr);
+
+#ifdef __cplusplus
+}
+#endif

--- a/include/aligned_malloc.h
+++ b/include/aligned_malloc.h
@@ -1,14 +1,4 @@
-#pragma once
-
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <stdlib.h>
 
 void *aligned_malloc(size_t align, size_t size);
 void aligned_free(void *ptr);
-
-#ifdef __cplusplus
-}
-#endif

--- a/src/aligned_malloc.c
+++ b/src/aligned_malloc.c
@@ -23,7 +23,6 @@
 
 // Number of bytes we're using for storing the aligned pointer offset
 typedef uint16_t offset_t;
-#define PTR_OFFSET_SZ sizeof(offset_t)
 
 /**
  * APIs
@@ -39,11 +38,12 @@ void *aligned_malloc(size_t align, size_t size) {
 
   // We want it to be a power of two since align_up operates on powers of two
   if (align && size && (align & (align - 1)) == 0) {
+    const size_t offset_size = sizeof(offset_t);
     /*
 	 * We know we have to fit an offset value
 	 * We also allocate extra bytes to ensure we can meet the alignment
 	 */
-    uint32_t hdr_size = PTR_OFFSET_SZ + (align - 1);
+    uint32_t hdr_size = offset_size + (align - 1);
     void *p = bm_malloc(size + hdr_size);
 
     if (p) {
@@ -51,7 +51,7 @@ void *aligned_malloc(size_t align, size_t size) {
 	   * Add the offset size to malloc's pointer (we will always store that)
 	   * Then align the resulting value to the arget alignment
 	   */
-      ptr = (void *)align_up(((uintptr_t)p + PTR_OFFSET_SZ), align);
+      ptr = (void *)align_up(((uintptr_t)p + offset_size), align);
 
       // Calculate the offset and store it behind our aligned pointer
       *((offset_t *)ptr - 1) = (offset_t)((uintptr_t)ptr - (uintptr_t)p);

--- a/src/aligned_malloc.c
+++ b/src/aligned_malloc.c
@@ -1,0 +1,82 @@
+//
+// aligned_malloc.c from https://embeddedartistry.com/blog/2017/02/22/generating-aligned-memory/
+// and https://github.com/embeddedartistry/embedded-resources/blob/master/examples/libc/malloc_aligned.c
+//
+// Modified to work with Bristlemouth bm_core bm_os.h
+//
+
+#include "aligned_malloc.h"
+#include "bm_os.h"
+#include <stdint.h>
+
+/**
+ * Definitions
+ */
+
+/**
+ * Simple macro for making sure memory addresses are aligned
+ * to the nearest power of two
+ */
+#ifndef align_up
+#define align_up(num, align) (((num) + ((align) - 1)) & ~((align) - 1))
+#endif
+
+// Number of bytes we're using for storing the aligned pointer offset
+typedef uint16_t offset_t;
+#define PTR_OFFSET_SZ sizeof(offset_t)
+
+/**
+ * APIs
+ */
+
+/**
+ * aligned_malloc takes in the requested alignment and size
+ *	We will call malloc with extra bytes for our header and the offset
+ *	required to guarantee the desired alignment.
+ */
+void *aligned_malloc(size_t align, size_t size) {
+  void *ptr = NULL;
+
+  // We want it to be a power of two since align_up operates on powers of two
+  if (align && size && (align & (align - 1)) == 0) {
+    /*
+	 * We know we have to fit an offset value
+	 * We also allocate extra bytes to ensure we can meet the alignment
+	 */
+    uint32_t hdr_size = PTR_OFFSET_SZ + (align - 1);
+    void *p = bm_malloc(size + hdr_size);
+
+    if (p) {
+      /*
+	   * Add the offset size to malloc's pointer (we will always store that)
+	   * Then align the resulting value to the arget alignment
+	   */
+      ptr = (void *)align_up(((uintptr_t)p + PTR_OFFSET_SZ), align);
+
+      // Calculate the offset and store it behind our aligned pointer
+      *((offset_t *)ptr - 1) = (offset_t)((uintptr_t)ptr - (uintptr_t)p);
+
+    } // else NULL, could not malloc
+  } // else NULL, invalid arguments
+
+  return ptr;
+}
+
+/**
+ * aligned_free works like free(), but we work backwards from the returned
+ * pointer to find the correct offset and pointer location to return to free()
+ * Note that it is VERY BAD to call free() on an aligned_malloc() pointer.
+ */
+void aligned_free(void *ptr) {
+  if (ptr) {
+    /*
+     * Walk backwards from the passed-in pointer to get the pointer offset
+     * We convert to an offset_t pointer and rely on pointer math to get the data
+     */
+    offset_t offset = *((offset_t *)ptr - 1);
+
+    // Once we have the offset, we can get our original pointer and call free
+    void *p = (void *)((uint8_t *)ptr - offset);
+    bm_free(p);
+  }
+}

--- a/src/aligned_malloc.c
+++ b/src/aligned_malloc.c
@@ -1,22 +1,13 @@
-//
 // aligned_malloc.c from https://embeddedartistry.com/blog/2017/02/22/generating-aligned-memory/
 // and https://github.com/embeddedartistry/embedded-resources/blob/master/examples/libc/malloc_aligned.c
 //
 // Modified to work with Bristlemouth bm_core bm_os.h
-//
 
 #include "aligned_malloc.h"
 #include "bm_os.h"
 #include <stdint.h>
 
-/**
- * Definitions
- */
-
-/**
- * Simple macro for making sure memory addresses are aligned
- * to the nearest power of two
- */
+// Align a pointer address upwards to the nearest given power of 2
 #ifndef align_up
 #define align_up(num, align) (((num) + ((align) - 1)) & ~((align) - 1))
 #endif
@@ -24,33 +15,15 @@
 // Number of bytes we're using for storing the aligned pointer offset
 typedef uint16_t offset_t;
 
-/**
- * APIs
- */
-
-/**
- * aligned_malloc takes in the requested alignment and size
- *	We will call malloc with extra bytes for our header and the offset
- *	required to guarantee the desired alignment.
- */
 void *aligned_malloc(size_t align, size_t size) {
   void *ptr = NULL;
 
-  // We want it to be a power of two since align_up operates on powers of two
+  // Align must be a power of two since align_up operates on powers of two
   if (align && size && (align & (align - 1)) == 0) {
     const size_t offset_size = sizeof(offset_t);
-    /*
-	 * We know we have to fit an offset value
-	 * We also allocate extra bytes to ensure we can meet the alignment
-	 */
     uint32_t hdr_size = offset_size + (align - 1);
     void *p = bm_malloc(size + hdr_size);
-
     if (p) {
-      /*
-	   * Add the offset size to malloc's pointer (we will always store that)
-	   * Then align the resulting value to the arget alignment
-	   */
       ptr = (void *)align_up(((uintptr_t)p + offset_size), align);
 
       // Calculate the offset and store it behind our aligned pointer

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -82,3 +82,13 @@ set (LIB_STATE_MACHINE_TEST_SRCS
     ${SRC_DIR}/lib_state_machine.c
 )
 create_gtest("lib_state_machine" "${LIB_STATE_MACHINE_TEST_SRCS}")
+
+# Aligned Malloc unit tests
+set (ALIGNED_MALLOC_TEST_SRCS
+    # File we are testing
+    ${SRC_DIR}/aligned_malloc.c
+
+    # Supporting files
+    ${STUB_DIR}/bm_os.c
+)
+create_gtest("aligned_malloc" "${ALIGNED_MALLOC_TEST_SRCS}")

--- a/test/src/aligned_malloc_test.cpp
+++ b/test/src/aligned_malloc_test.cpp
@@ -23,56 +23,68 @@ TEST(AlignedMalloc, happy_path) {
 TEST(AlignedMalloc, alignment_must_be_power_of_two) {
   void *ptr = aligned_malloc(3, 16);
   EXPECT_EQ(ptr, nullptr);
+  aligned_free(ptr);
   ptr = aligned_malloc(5, 16);
   EXPECT_EQ(ptr, nullptr);
+  aligned_free(ptr);
   ptr = aligned_malloc(6, 16);
   EXPECT_EQ(ptr, nullptr);
+  aligned_free(ptr);
   ptr = aligned_malloc(7, 16);
   EXPECT_EQ(ptr, nullptr);
+  aligned_free(ptr);
 }
 
 TEST(AlignedMalloc, size_zero_not_allowed) {
   void *ptr = aligned_malloc(16, 0);
   EXPECT_EQ(ptr, nullptr);
+  aligned_free(ptr);
 }
 
 TEST(AlignedMalloc, alignment_zero_not_allowed) {
   void *ptr = aligned_malloc(0, 16);
   EXPECT_EQ(ptr, nullptr);
+  aligned_free(ptr);
 }
 
 TEST(AlignedMalloc, align8) {
   void *ptr = aligned_malloc(8, 37);
   EXPECT_NE(ptr, nullptr);
   EXPECT_EQ((uintptr_t)ptr % 8, 0);
+  aligned_free(ptr);
 }
 
 TEST(AlignedMalloc, align16) {
   void *ptr = aligned_malloc(16, 37);
   EXPECT_NE(ptr, nullptr);
   EXPECT_EQ((uintptr_t)ptr % 16, 0);
+  aligned_free(ptr);
 }
 
 TEST(AlignedMalloc, align32) {
   void *ptr = aligned_malloc(32, 37);
   EXPECT_NE(ptr, nullptr);
   EXPECT_EQ((uintptr_t)ptr % 32, 0);
+  aligned_free(ptr);
 }
 
 TEST(AlignedMalloc, align64) {
   void *ptr = aligned_malloc(64, 37);
   EXPECT_NE(ptr, nullptr);
   EXPECT_EQ((uintptr_t)ptr % 64, 0);
+  aligned_free(ptr);
 }
 
 TEST(AlignedMalloc, align128) {
   void *ptr = aligned_malloc(128, 37);
   EXPECT_NE(ptr, nullptr);
   EXPECT_EQ((uintptr_t)ptr % 128, 0);
+  aligned_free(ptr);
 }
 
 TEST(AlignedMalloc, align256) {
   void *ptr = aligned_malloc(256, 37);
   EXPECT_NE(ptr, nullptr);
   EXPECT_EQ((uintptr_t)ptr % 256, 0);
+  aligned_free(ptr);
 }

--- a/test/src/aligned_malloc_test.cpp
+++ b/test/src/aligned_malloc_test.cpp
@@ -1,0 +1,78 @@
+#include "fff.h"
+#include "gtest/gtest.h"
+
+DEFINE_FFF_GLOBALS;
+
+extern "C" {
+#include "aligned_malloc.h"
+}
+
+TEST(AlignedMalloc, happy_path) {
+  const char buffer[] =
+      "Lorem ipsum dolor sit amet, consectetur adipiscing elit, "
+      "sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.";
+  const size_t buffer_size = sizeof(buffer);
+  void *ptr = aligned_malloc(4, buffer_size);
+  EXPECT_NE(ptr, nullptr);
+  EXPECT_EQ((uintptr_t)ptr % 4, 0);
+  memcpy(ptr, buffer, buffer_size);
+  EXPECT_STREQ((const char *)ptr, buffer);
+  aligned_free(ptr);
+}
+
+TEST(AlignedMalloc, alignment_must_be_power_of_two) {
+  void *ptr = aligned_malloc(3, 16);
+  EXPECT_EQ(ptr, nullptr);
+  ptr = aligned_malloc(5, 16);
+  EXPECT_EQ(ptr, nullptr);
+  ptr = aligned_malloc(6, 16);
+  EXPECT_EQ(ptr, nullptr);
+  ptr = aligned_malloc(7, 16);
+  EXPECT_EQ(ptr, nullptr);
+}
+
+TEST(AlignedMalloc, size_zero_not_allowed) {
+  void *ptr = aligned_malloc(16, 0);
+  EXPECT_EQ(ptr, nullptr);
+}
+
+TEST(AlignedMalloc, alignment_zero_not_allowed) {
+  void *ptr = aligned_malloc(0, 16);
+  EXPECT_EQ(ptr, nullptr);
+}
+
+TEST(AlignedMalloc, align8) {
+  void *ptr = aligned_malloc(8, 37);
+  EXPECT_NE(ptr, nullptr);
+  EXPECT_EQ((uintptr_t)ptr % 8, 0);
+}
+
+TEST(AlignedMalloc, align16) {
+  void *ptr = aligned_malloc(16, 37);
+  EXPECT_NE(ptr, nullptr);
+  EXPECT_EQ((uintptr_t)ptr % 16, 0);
+}
+
+TEST(AlignedMalloc, align32) {
+  void *ptr = aligned_malloc(32, 37);
+  EXPECT_NE(ptr, nullptr);
+  EXPECT_EQ((uintptr_t)ptr % 32, 0);
+}
+
+TEST(AlignedMalloc, align64) {
+  void *ptr = aligned_malloc(64, 37);
+  EXPECT_NE(ptr, nullptr);
+  EXPECT_EQ((uintptr_t)ptr % 64, 0);
+}
+
+TEST(AlignedMalloc, align128) {
+  void *ptr = aligned_malloc(128, 37);
+  EXPECT_NE(ptr, nullptr);
+  EXPECT_EQ((uintptr_t)ptr % 128, 0);
+}
+
+TEST(AlignedMalloc, align256) {
+  void *ptr = aligned_malloc(256, 37);
+  EXPECT_NE(ptr, nullptr);
+  EXPECT_EQ((uintptr_t)ptr % 256, 0);
+}


### PR DESCRIPTION
Currently, the only usage of `aligned_malloc` in Bristlemouth is by the adin driver to ensure that our DMA buffers are appropriately aligned. However, since it is a small, self-contained layer on top of `bm_malloc` that any future code might need, its best home is here in `bm_common`.

I also added unit tests verifying the advertised functionality.

```
      Start  6: AlignedMalloc.happy_path
 6/15 Test  #6: AlignedMalloc.happy_path .......................   Passed    0.03 sec
      Start  7: AlignedMalloc.alignment_must_be_power_of_two
 7/15 Test  #7: AlignedMalloc.alignment_must_be_power_of_two ...   Passed    0.00 sec
      Start  8: AlignedMalloc.size_zero_not_allowed
 8/15 Test  #8: AlignedMalloc.size_zero_not_allowed ............   Passed    0.00 sec
      Start  9: AlignedMalloc.alignment_zero_not_allowed
 9/15 Test  #9: AlignedMalloc.alignment_zero_not_allowed .......   Passed    0.00 sec
      Start 10: AlignedMalloc.align8
10/15 Test #10: AlignedMalloc.align8 ...........................   Passed    0.00 sec
      Start 11: AlignedMalloc.align16
11/15 Test #11: AlignedMalloc.align16 ..........................   Passed    0.00 sec
      Start 12: AlignedMalloc.align32
12/15 Test #12: AlignedMalloc.align32 ..........................   Passed    0.00 sec
      Start 13: AlignedMalloc.align64
13/15 Test #13: AlignedMalloc.align64 ..........................   Passed    0.00 sec
      Start 14: AlignedMalloc.align128
14/15 Test #14: AlignedMalloc.align128 .........................   Passed    0.00 sec
      Start 15: AlignedMalloc.align256
15/15 Test #15: AlignedMalloc.align256 .........................   Passed    0.00 sec
```